### PR TITLE
Fix: List error handling

### DIFF
--- a/lib/src/features/borrowers/presentation/borrowers_desktop_layout.dart
+++ b/lib/src/features/borrowers/presentation/borrowers_desktop_layout.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:librarian_app/src/features/borrowers/data/borrowers_view_model.dart';
 import 'package:librarian_app/src/features/borrowers/presentation/borrower_details_pane.dart';
-import 'package:librarian_app/src/features/borrowers/presentation/borrowers_list.dart';
+import 'package:librarian_app/src/features/borrowers/views/borrowers_view.dart';
 import 'package:librarian_app/src/features/common/widgets/dashboard/pane_header.dart';
 import 'package:librarian_app/src/features/common/widgets/search_field.dart';
 import 'package:provider/provider.dart';
@@ -41,12 +41,11 @@ class _BorrowersDesktopLayoutState extends State<BorrowersDesktopLayout> {
                             },
                           ),
                         ),
-                        BorrowersList(
-                          borrowers: model.filtered(_searchFilter),
-                          selected: model.selectedBorrower,
-                          onTap: (borrower) {
-                            model.selectedBorrower = borrower;
-                          },
+                        Expanded(
+                          child: BorrowersView(
+                            model: model,
+                            searchFilter: _searchFilter,
+                          ),
                         ),
                       ],
                     );

--- a/lib/src/features/borrowers/presentation/connected_borrowers_list.dart
+++ b/lib/src/features/borrowers/presentation/connected_borrowers_list.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:librarian_app/src/features/borrowers/data/borrowers_view_model.dart';
-import 'package:librarian_app/src/features/borrowers/presentation/borrowers_list.dart';
+import 'package:librarian_app/src/features/borrowers/views/borrowers_view.dart';
 import 'package:provider/provider.dart';
 
 import '../data/borrower_model.dart';
@@ -19,28 +19,10 @@ class ConnectedBorrowersList extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<BorrowersViewModel>(
       builder: (context, model, child) {
-        if (model.errorMessage != null) {
-          return Center(child: Text(model.errorMessage!));
-        }
-
-        if (model.isLoading) {
-          return const Center(child: CircularProgressIndicator());
-        }
-
-        var localBorrowers = model.borrowers;
-        if (filter != null) {
-          localBorrowers = localBorrowers
-              .where((b) => b.name.toLowerCase().contains(filter!))
-              .toList();
-        }
-
-        return BorrowersList(
-          borrowers: localBorrowers,
-          onTap: (b) {
-            model.selectedBorrower = b;
-            onTap?.call(b);
-          },
-          selected: onTap == null ? model.selectedBorrower : null,
+        return BorrowersView(
+          model: model,
+          searchFilter: filter ?? '',
+          onTap: onTap,
         );
       },
     );

--- a/lib/src/features/borrowers/views/borrowers_view.dart
+++ b/lib/src/features/borrowers/views/borrowers_view.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:librarian_app/src/features/borrowers/data/borrowers_view_model.dart';
+
+import '../presentation/borrowers_list.dart';
+
+class BorrowersView extends StatelessWidget {
+  const BorrowersView({
+    super.key,
+    required this.model,
+    required this.searchFilter,
+  });
+
+  final BorrowersViewModel model;
+  final String searchFilter;
+
+  @override
+  Widget build(BuildContext context) {
+    if (model.errorMessage != null) {
+      return Center(child: Text(model.errorMessage!));
+    }
+
+    if (model.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final borrowers = model.filtered(searchFilter);
+
+    if (borrowers.isEmpty) {
+      return const Center(child: Text('No results found'));
+    }
+
+    return BorrowersList(
+      borrowers: model.filtered(searchFilter),
+      selected: model.selectedBorrower,
+      onTap: (borrower) {
+        model.selectedBorrower = borrower;
+      },
+    );
+  }
+}

--- a/lib/src/features/borrowers/views/borrowers_view.dart
+++ b/lib/src/features/borrowers/views/borrowers_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:librarian_app/src/features/borrowers/data/borrowers_view_model.dart';
 
+import '../data/borrower_model.dart';
 import '../presentation/borrowers_list.dart';
 
 class BorrowersView extends StatelessWidget {
@@ -8,10 +9,12 @@ class BorrowersView extends StatelessWidget {
     super.key,
     required this.model,
     required this.searchFilter,
+    this.onTap,
   });
 
   final BorrowersViewModel model;
   final String searchFilter;
+  final void Function(BorrowerModel)? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -34,6 +37,7 @@ class BorrowersView extends StatelessWidget {
       selected: model.selectedBorrower,
       onTap: (borrower) {
         model.selectedBorrower = borrower;
+        onTap?.call(borrower);
       },
     );
   }

--- a/lib/src/features/loans/presentation/connected_loans_list.dart
+++ b/lib/src/features/loans/presentation/connected_loans_list.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:librarian_app/src/features/loans/presentation/loans_list.dart';
+import 'package:librarian_app/src/features/loans/views/loans_view.dart';
 import 'package:provider/provider.dart';
 
 import '../data/loan_model.dart';
@@ -19,31 +19,10 @@ class ConnectedLoansList extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<LoansViewModel>(
       builder: (context, model, child) {
-        if (model.errorMessage != null) {
-          return Center(child: Text(model.errorMessage!));
-        }
-
-        if (model.isLoading) {
-          return const Center(child: CircularProgressIndicator());
-        }
-
-        var localLoans = model.loans;
-
-        if (localLoans.isNotEmpty && filter != null && filter!.isNotEmpty) {
-          localLoans = localLoans.where((loan) {
-            final borrowerName = loan.borrower.name.toLowerCase();
-            final filterText = filter!.toLowerCase();
-            return borrowerName.contains(filterText);
-          }).toList();
-        }
-
-        return LoansList(
-          loans: localLoans,
-          selected: model.selectedLoan,
-          onTap: (l) {
-            model.selectedLoan = l;
-            onTap?.call(l);
-          },
+        return LoansView(
+          model: model,
+          searchFilter: filter ?? '',
+          onTap: onTap,
         );
       },
     );

--- a/lib/src/features/loans/presentation/loans_desktop_layout.dart
+++ b/lib/src/features/loans/presentation/loans_desktop_layout.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:librarian_app/src/features/common/widgets/dashboard/pane_header.dart';
 import 'package:librarian_app/src/features/common/widgets/search_field.dart';
 import 'package:librarian_app/src/features/loans/presentation/loan_details_pane.dart';
-import 'package:librarian_app/src/features/loans/presentation/loans_list.dart';
+import 'package:librarian_app/src/features/loans/views/loans_view.dart';
 import 'package:provider/provider.dart';
 
 import '../data/loans_view_model.dart';
@@ -40,10 +40,11 @@ class _LoansDesktopLayoutState extends State<LoansDesktopLayout> {
                         },
                       ),
                     ),
-                    LoansList(
-                      loans: model.filtered(_searchFilter),
-                      selected: model.selectedLoan,
-                      onTap: (loan) => model.selectedLoan = loan,
+                    Expanded(
+                      child: LoansView(
+                        model: model,
+                        searchFilter: _searchFilter,
+                      ),
                     ),
                   ],
                 );

--- a/lib/src/features/loans/views/loans_view.dart
+++ b/lib/src/features/loans/views/loans_view.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../data/loans_view_model.dart';
+import '../presentation/loans_list.dart';
+
+class LoansView extends StatelessWidget {
+  const LoansView({
+    super.key,
+    required this.model,
+    required this.searchFilter,
+  });
+
+  final LoansViewModel model;
+  final String searchFilter;
+
+  @override
+  Widget build(BuildContext context) {
+    if (model.errorMessage != null) {
+      return Center(child: Text(model.errorMessage!));
+    }
+
+    if (model.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final loans = model.filtered(searchFilter);
+
+    if (loans.isEmpty) {
+      return const Center(child: Text('No results found'));
+    }
+
+    return LoansList(
+      loans: loans,
+      selected: model.selectedLoan,
+      onTap: (loan) => model.selectedLoan = loan,
+    );
+  }
+}

--- a/lib/src/features/loans/views/loans_view.dart
+++ b/lib/src/features/loans/views/loans_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../data/loan_model.dart';
 import '../data/loans_view_model.dart';
 import '../presentation/loans_list.dart';
 
@@ -8,10 +9,12 @@ class LoansView extends StatelessWidget {
     super.key,
     required this.model,
     required this.searchFilter,
+    this.onTap,
   });
 
   final LoansViewModel model;
   final String searchFilter;
+  final void Function(LoanModel)? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +35,10 @@ class LoansView extends StatelessWidget {
     return LoansList(
       loans: loans,
       selected: model.selectedLoan,
-      onTap: (loan) => model.selectedLoan = loan,
+      onTap: (loan) {
+        model.selectedLoan = loan;
+        onTap?.call(loan);
+      },
     );
   }
 }


### PR DESCRIPTION
When I refactored how the lists of loans/borrowers are displayed on desktop, I neglected to include error handling! This change adds error handling back in and begins to clean up the older "connected" widgets.

In the future, all widgets with knowledge of the ViewModel will go in a `views` directory, while others will go under a `widgets` directory.