### PR TITLE
Accomodate more edge cases when building initials

### DIFF
--- a/lib/src/features/loans/widgets/loans_list/loans_list.widget.dart
+++ b/lib/src/features/loans/widgets/loans_list/loans_list.widget.dart
@@ -15,16 +15,6 @@ class LoansList extends StatelessWidget {
     this.onTap,
   });
 
-  String _getBorrowerInitials(String name) {
-    final uppercaseName = name.toUpperCase();
-    final firstLetter = uppercaseName[0];
-
-    final split = uppercaseName.split(' ');
-    final secondLetter = split.length > 1 ? split[1][0] : uppercaseName[1];
-
-    return firstLetter + secondLetter;
-  }
-
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
@@ -34,7 +24,7 @@ class LoansList extends StatelessWidget {
 
         final thingNumber = Text('#${loan.thing.number}');
         final thingName = Text(loan.thing.name);
-        final borrowerInitials = _getBorrowerInitials(loan.borrower.name);
+        final borrowerInitials = Initials.convert(loan.borrower.name);
 
         return ListTile(
           leading: CircleAvatar(
@@ -64,5 +54,21 @@ class LoansList extends StatelessWidget {
       },
       shrinkWrap: true,
     );
+  }
+}
+
+class Initials {
+  static String convert(String fullName) {
+    final trimmedName = fullName.trim().toUpperCase();
+    if (trimmedName.isEmpty) {
+      return '?';
+    }
+
+    final firstLetter = trimmedName[0];
+
+    final split = trimmedName.split(' ');
+    final secondLetter = split.length > 1 ? split.last[0] : trimmedName[1];
+
+    return firstLetter + secondLetter;
   }
 }

--- a/test/loans/initials_test.dart
+++ b/test/loans/initials_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:librarian_app/src/features/loans/widgets/loans_list/loans_list.widget.dart';
+
+void main() {
+  group('Initials', () {
+    for (TestCase t in [
+      const TestCase('Alice Alisson', 'AA'),
+      const TestCase('Ponce de Leon', 'PL'),
+      const TestCase('Double  Spaces', 'DS'),
+      const TestCase('NoSpaces', 'NO'),
+      const TestCase('Weird ness ', 'WN'),
+      const TestCase(' ', '?'),
+      const TestCase('', '?'),
+    ]) {
+      test('#convert(${t.fullName}) returns ${t.expected}', () {
+        final result = Initials.convert(t.fullName);
+        expect(result, t.expected);
+      });
+    }
+  });
+}
+
+class TestCase {
+  const TestCase(this.fullName, this.expected);
+
+  final String fullName;
+  final String expected;
+}


### PR DESCRIPTION
Some borrowers' names in the production DB are breaking the initial generation. Added handling for more edge cases so we're not dependent on the quality of the data.