### PR TITLE
Fix thing image refresh

### DIFF
--- a/lib/src/features/inventory/data/inventory.vm.dart
+++ b/lib/src/features/inventory/data/inventory.vm.dart
@@ -77,7 +77,7 @@ class InventoryViewModel extends ChangeNotifier {
       image: image,
     );
 
-    refresh();
+    Future.delayed(Duration(seconds: image != null ? 1 : 0), refresh);
   }
 
   Future<void> createItems({

--- a/lib/src/features/inventory/services/inventory.service.dart
+++ b/lib/src/features/inventory/services/inventory.service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:librarian_app/src/features/common/services/image_service.dart';
 import 'package:librarian_app/src/features/inventory/data/updated_image_model.dart';
 
@@ -63,7 +64,7 @@ class InventoryService {
       name: name,
       spanishName: spanishName,
       hidden: hidden,
-      imageUrl: image != null && image.bytes != null
+      imageUrl: image != null && image.bytes != null && !kDebugMode
           ? (await _imageService.uploadImage(
               bytes: image.bytes!,
               type: image.type!,


### PR DESCRIPTION
I think the image refresh bug in production might be caused by us prematurely refreshing. Airtable might not have finished adding the image before sending information back.

Also adding handling for debug mode, so that Save works locally.