### PR TITLE
Filter borrowers locally in search delegate

### DIFF
--- a/lib/src/features/borrowers/widgets/borrower_search_delegate.dart
+++ b/lib/src/features/borrowers/widgets/borrower_search_delegate.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 
 import '../models/borrower_model.dart';
-import 'borrowers_list/borrowers_list_view.dart';
+import 'borrowers_list/borrowers_list.dart';
 
 class BorrowerSearchDelegate extends SearchDelegate<BorrowerModel?> {
-  BorrowerSearchDelegate();
+  BorrowerSearchDelegate(this.borrowers);
+
+  final List<BorrowerModel> borrowers;
 
   @override
   List<Widget>? buildActions(BuildContext context) {
@@ -29,15 +31,24 @@ class BorrowerSearchDelegate extends SearchDelegate<BorrowerModel?> {
 
   @override
   Widget buildResults(BuildContext context) {
-    return BorrowersView(
-      onTap: (borrower) => close(context, borrower),
-    );
+    return _buildQueriedList(context);
   }
 
   @override
   Widget buildSuggestions(BuildContext context) {
-    return BorrowersView(
-      onTap: (borrower) => close(context, borrower),
+    return _buildQueriedList(context);
+  }
+
+  Widget _buildQueriedList(BuildContext context) {
+    final results = borrowers
+        .where((b) => b.name.toLowerCase().contains(query.toLowerCase()))
+        .toList();
+
+    return BorrowersList(
+      borrowers: results,
+      onTap: (borrower) {
+        close(context, borrower);
+      },
     );
   }
 }

--- a/lib/src/features/loans/widgets/checkout/checkout_stepper.dart
+++ b/lib/src/features/loans/widgets/checkout/checkout_stepper.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:librarian_app/src/features/borrowers/models/borrower_model.dart';
+import 'package:librarian_app/src/features/borrowers/providers/borrowers_provider.dart';
 import 'package:librarian_app/src/features/borrowers/providers/borrowers_repository_provider.dart';
 import 'package:librarian_app/src/features/borrowers/widgets/borrower_details/borrower_issues.dart';
 import 'package:librarian_app/src/features/borrowers/widgets/borrower_search_delegate.dart';
@@ -113,16 +114,18 @@ class _CheckoutStepperState extends ConsumerState<CheckoutStepper> {
                   labelText: 'Borrower',
                   prefixIcon: Icon(Icons.person_rounded),
                 ),
-                onTap: () async {
-                  final borrower = await showSearch(
-                    context: context,
-                    delegate: BorrowerSearchDelegate(),
-                    useRootNavigator: true,
-                  );
-
-                  if (borrower != null) {
-                    setState(() => _borrower = borrower);
-                  }
+                onTap: () {
+                  ref.read(borrowersProvider).then((borrowers) async {
+                    return await showSearch(
+                      context: context,
+                      delegate: BorrowerSearchDelegate(borrowers),
+                      useRootNavigator: true,
+                    );
+                  }).then((borrower) {
+                    if (borrower != null) {
+                      setState(() => _borrower = borrower);
+                    }
+                  });
                 },
               ),
               if (_borrower != null && !_borrower!.active) ...[


### PR DESCRIPTION
When opening a loan, the list of borrowers was not filtering based on the typed query. The refactored code in the search delegate was not hooked up to the query and the ListView was not updating.

Passed in the list of borrowers from the checkout stepper and implemented filtering inside the search delegate.