### PR TITLE
Read all borrowers from repo when creating loan

### DIFF
--- a/lib/src/features/loans/widgets/checkout/checkout_stepper.dart
+++ b/lib/src/features/loans/widgets/checkout/checkout_stepper.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:librarian_app/src/features/borrowers/models/borrower_model.dart';
-import 'package:librarian_app/src/features/borrowers/providers/borrowers_provider.dart';
 import 'package:librarian_app/src/features/borrowers/providers/borrowers_repository_provider.dart';
 import 'package:librarian_app/src/features/borrowers/widgets/borrower_details/borrower_issues.dart';
 import 'package:librarian_app/src/features/borrowers/widgets/borrower_search_delegate.dart';
@@ -117,7 +116,7 @@ class _CheckoutStepperState extends ConsumerState<CheckoutStepper> {
                 ),
                 onTap: () {
                   ref.invalidate(borrowersRepositoryProvider);
-                  ref.read(borrowersProvider).then((borrowers) async {
+                  ref.read(borrowersRepositoryProvider).then((borrowers) async {
                     return await showSearch(
                       context: context,
                       delegate: BorrowerSearchDelegate(borrowers),


### PR DESCRIPTION
When creating a loan, we were pulling the borrowers from the filtered provider, which could cause the list of borrowers to be incomplete if the user had searched from the Borrowers screen.